### PR TITLE
Disable HDMI with /boot/config.txt

### DIFF
--- a/raspberrypi/setup.sh
+++ b/raspberrypi/setup.sh
@@ -19,7 +19,7 @@ sudo depmod -A || { echo "Error: Failed to update module dependencies."; exit 1;
 echo 'sharp' | sudo tee -a /etc/modules
 dtc -@ -I dts -O dtb -o sharp.dtbo sharp.dts || { echo "Error: Failed to compile device tree."; exit 1; }
 sudo cp sharp.dtbo /boot/overlays
-echo -e "framebuffer_width=400\nframebuffer_height=240\ndtoverlay=sharp" | sudo tee -a /boot/config.txt
+echo -e "framebuffer_width=400\nframebuffer_height=240\ndtoverlay=sharp\nhdmi_blanking=1\nhdmi_ignore_hotplug=1\nhdmi_ignore_composite=1" | sudo tee -a /boot/config.txt
 sudo sed -i ' 1 s/.*/& fbcon=map:10 fbcon=font:VGA8x16/' /boot/cmdline.txt || { echo "Error: Failed to modify cmdline.txt."; exit 1; }
 
 echo "Compiling and installing keyboard device driver..."


### PR DESCRIPTION
According to https://github.com/raspberrypi/userland/issues/447 we can add these lines to /boot/config.txt to disable the display pipeline:

```
hdmi_ignore_hotplug=1
hdmi_ignore_composite=1
```

Should save some power. Also added `hdmi_blanking=1` for good measure.