### PR TITLE
optimize_boot: remove disable keyboard-setup

### DIFF
--- a/raspberrypi/optimize_boot.sh
+++ b/raspberrypi/optimize_boot.sh
@@ -22,6 +22,5 @@ systemctl disable polkit
 systemctl disable ModemManager
 systemctl disable avahi-daemon
 systemctl disable dphys-swapfile
-systemctl disable keyboard-setup
 systemctl disable apt-daily
 systemctl disable raspi-config


### PR DESCRIPTION
keyboard-setup is apparently required in order for at least alt and altGrave key modifiers to work.
fixes: #27 